### PR TITLE
refactor: rely solely on ai summaries

### DIFF
--- a/obelisk-engine/src/cluster.ts
+++ b/obelisk-engine/src/cluster.ts
@@ -1,12 +1,8 @@
 import { NewsItem, NewsCluster } from './types';
-import { 
-  extractShingles, 
-  jaccardSimilarity, 
+import {
+  extractShingles,
+  jaccardSimilarity,
   isSameArticle,
-  normalizeText,
-  generateNeutralHeadline,
-  generateBulletSummary,
-  generateAISummary,
   selectBestHeadline
 } from './normalize';
 
@@ -133,8 +129,8 @@ export function clusterNewsItems(items: NewsItem[], similarityThreshold: number 
   // Build clusters from Union-Find structure
   const clusterMap = uf.getClusters();
   const clusters: NewsCluster[] = [];
-  
-  // Generate clusters with AI summaries
+
+  // Build clusters from grouped items
   for (const [rootId, memberIds] of clusterMap) {
     const clusterItems = memberIds.map(id => uniqueItems.get(id)!);
     
@@ -151,15 +147,13 @@ export function clusterNewsItems(items: NewsItem[], similarityThreshold: number 
     // Select the best headline from available sources
     const clusterTitle = clusterItems[0].title;
     const clusterHeadline = selectBestHeadline(clusterItems);
-    const bulletSummary = generateBulletSummary(clusterItems);
-    
+
     clusters.push({
       id: `cluster_${clusters.length}`,
       coverage: sources.size,
       updated_at: clusterItems[0].published_at,
       title: clusterTitle,
       neutral_headline: clusterHeadline,
-      bullet_summary: bulletSummary,
       items: clusterItems,
       featured_image: clusterItems.find(item => item.image_url)?.image_url
     });

--- a/obelisk-engine/src/normalize.ts
+++ b/obelisk-engine/src/normalize.ts
@@ -179,58 +179,6 @@ export function generateClusterHeadline(items: NewsItem[]): string {
   return generateNeutralHeadline(items[0].title, items[0].content);
 }
 
-export function generateBulletSummary(items: NewsItem[]): string[] {
-  if (items.length === 0) return [];
-
-  const bullets: string[] = [];
-  const processedFacts = new Set<string>();
-
-  // Extract key facts from each article
-  items.forEach(item => {
-    const text = item.standfirst || item.content || '';
-    if (!text || text.length < 50) return;
-
-    // Split into sentences and find informative ones
-    const sentences = text
-      .split(/[.!?]+/)
-      .map(s => s.trim())
-      .filter(s => s.length > 20 && s.length < 200);
-
-    sentences.forEach(sentence => {
-      // Skip if we've seen a similar fact
-      const normalizedSentence = normalizeText(sentence);
-      if (processedFacts.has(normalizedSentence)) return;
-
-      // Look for factual statements (contain numbers, names, specific actions)
-      const hasNumbers = /\d+/.test(sentence);
-      const hasProperNouns = /[A-Z][a-z]+/.test(sentence);
-      const hasActionWords = /(said|announced|reported|confirmed|stated|revealed|showed|found)/i.test(sentence);
-
-      if ((hasNumbers || hasProperNouns) && hasActionWords) {
-        // Clean up the sentence
-        let cleanSentence = sentence
-          .replace(/^(according to|sources say|reports suggest|it is reported)/i, '')
-          .replace(/\s+/g, ' ')
-          .trim();
-
-        if (cleanSentence.length > 15) {
-          bullets.push(cleanSentence);
-          processedFacts.add(normalizedSentence);
-        }
-      }
-    });
-  });
-
-  // If we don't have enough bullets, add source attribution
-  if (bullets.length < 2) {
-    const sources = [...new Set(items.map(item => item.source))];
-    bullets.push(`Reported by ${sources.slice(0, 3).join(', ')}${sources.length > 3 ? ' and others' : ''}`);
-  }
-
-  // Limit to 4 key points
-  return bullets.slice(0, 4);
-}
-
 // Batch process multiple clusters with Gemini API in smaller chunks
 export async function generateBatchAISummaries(clusters: any[], env?: any): Promise<void> {
   if (clusters.length === 0) return;

--- a/obelisk-engine/src/types.ts
+++ b/obelisk-engine/src/types.ts
@@ -16,7 +16,6 @@ export interface NewsCluster {
   updated_at: string;
   title: string;
   neutral_headline?: string;
-  bullet_summary?: string[];
   ai_summary?: string[] | string; // AI-generated summary (array of bullets or legacy string format)
   items: NewsItem[];
   popularity_score?: number; // Calculated popularity score for sorting

--- a/obelisk-engine/src/worker.ts
+++ b/obelisk-engine/src/worker.ts
@@ -3,7 +3,6 @@ import { FEED_SOURCES, getFeedsBySection } from './feeds';
 import { fetchAllFeeds, fetchEvidenceAlerts } from './fetcher';
 import { clusterNewsItems } from './cluster';
 import { fetchScrapedPopularArticles } from './scraper';
-import { generateAISummary, generateAIHeadline } from './normalize';
 
 export default {
   async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
@@ -59,10 +58,10 @@ export default {
         ]);
 
         const response: MedicalSectionData = {
-          clinical: clinical || { clusters: [], updated_at: new Date().toISOString() },
-          professional: professional || { clusters: [], updated_at: new Date().toISOString() },
-          patient_signals: patientSignals || { clusters: [], updated_at: new Date().toISOString() },
-          month_in_research: monthInResearch || { clusters: [], updated_at: new Date().toISOString() }
+          clinical: (clinical as SectionData) || { clusters: [], updated_at: new Date().toISOString() },
+          professional: (professional as SectionData) || { clusters: [], updated_at: new Date().toISOString() },
+          patient_signals: (patientSignals as SectionData) || { clusters: [], updated_at: new Date().toISOString() },
+          month_in_research: (monthInResearch as SectionData) || { clusters: [], updated_at: new Date().toISOString() }
         };
 
         return new Response(JSON.stringify(response), { headers: corsHeaders });

--- a/scripts/js/news-new.js
+++ b/scripts/js/news-new.js
@@ -653,10 +653,9 @@ function openModal(clusterId) {
     // Add "In Brief" section
     modalHTML += `<h3 class="modal-section-title">In Brief</h3>`;
     
-    // Try different possible summary fields
+    // Only use ai_summary for brief points
     let summaryPoints = null;
-    
-    // Handle ai_summary which can be either array or string with newlines
+
     if (cluster.ai_summary) {
         if (Array.isArray(cluster.ai_summary)) {
             summaryPoints = cluster.ai_summary;
@@ -667,12 +666,8 @@ function openModal(clusterId) {
                 .map(line => line.replace(/^[•\-]\s*/, '').trim())
                 .filter(line => line.length > 0);
         }
-    } else if (cluster.bullet_summary && Array.isArray(cluster.bullet_summary)) {
-        summaryPoints = cluster.bullet_summary;
-    } else if (cluster.summary && Array.isArray(cluster.summary)) {
-        summaryPoints = cluster.summary;
     }
-    
+
     if (summaryPoints && summaryPoints.length > 0) {
         modalHTML += `<ul class="in-brief-list">`;
         summaryPoints.forEach((point, index) => {
@@ -685,15 +680,9 @@ function openModal(clusterId) {
         });
         modalHTML += `</ul>`;
     } else {
-        // Debug: log the cluster structure to console
-        console.log('No summary found for cluster:', cluster);
+        console.log('No ai_summary available for cluster:', cluster);
         modalHTML += `
-            <ul class="in-brief-list">
-                <li class="brief-item">
-                    <div class="brief-number">1</div>
-                    <div class="brief-text">No summary available for this story.</div>
-                </li>
-            </ul>
+            <p class="in-brief-fallback">This story may be too hard for me to put simply. Click through to the full article to learn more instead.</p>
         `;
     }
     


### PR DESCRIPTION
## Summary
- remove legacy bullet_summary handling in news modal and show friendly fallback when no AI summary
- drop bullet_summary from dataset types and generation
- tidy worker imports and cluster comments to reflect ai_summary-only approach

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a528261a40832ea423578f50e90834