### PR TITLE
Fix CSS alignment issues in Medical and Evidence sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -643,7 +643,7 @@
             .evidence-article {
                 display: flex;
                 justify-content: space-between;
-                align-items: center;
+                align-items: flex-start;
                 padding: 10px;
                 cursor: pointer;
                 transition: all 0.2s;
@@ -658,7 +658,7 @@
                 flex: 1;
                 max-width: 100%;
                 display: flex;
-                align-items: center;
+                align-items: flex-start;
                 gap: 15px;
             }
 
@@ -2387,7 +2387,7 @@
             /* Medical lens toggle styles */
             .medical-top-stories-header {
                 display: flex;
-                align-items: flex-end;
+                align-items: center;
                 gap: 6px;
                 margin: 15px 0 10px 10px;
                 width: 100%;


### PR DESCRIPTION
- Medical Top Stories: Change align-items from flex-end to center to match Other Stories box padding
- Evidence articles: Change align-items from center to flex-start so titles align with badge/date

https://claude.ai/code/session_017kaVxG5LbVzUoxLA457ioi